### PR TITLE
Added cli command "init" to create a new smart contract with generated boilerplate code

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/CityOfZion/neo-go/pkg/rpc"
 	"github.com/CityOfZion/neo-storm/compiler"
@@ -15,7 +16,21 @@ import (
 )
 
 var (
-	errNoInput = errors.New("No input file was found, specify an input file with the '--in or -i' flag")
+	errNoInput             = errors.New("No input file was found, specify an input file with the '--in or -i' flag")
+	errNoSmartContractName = errors.New("No name was provided, specify the '--name or -n' flag")
+	errFileExist           = errors.New("A file with given smart-contract name already exists")
+)
+
+var (
+	// smartContractTmpl is written to a file when used with `init` command.
+	// %s is parsed to be the smartContractName
+	smartContractTmpl = `package %s
+
+import "github.com/CityOfZion/neo-storm/interop/runtime"
+
+func Main(op string, args []interface{}) {
+    runtime.Notify("Hello world!")
+}`
 )
 
 func main() {
@@ -53,8 +68,49 @@ func main() {
 				},
 			},
 		},
+		{
+			Name:   "init",
+			Usage:  "initialize a new smart-contract in a directory with boiler plate code",
+			Action: initSmartContract,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "name, n",
+					Usage: "name of the smart-contract to be initialized",
+				},
+			},
+		},
 	}
 	ctl.Run(os.Args)
+}
+
+// initSmartContract initializes a given directory with some boiler plate code.
+func initSmartContract(ctx *cli.Context) error {
+	scName := ctx.String("name")
+	if scName == "" {
+		return cli.NewExitError(errNoSmartContractName, 1)
+	}
+
+	// Check if the file already exists, if yes, exit
+	if _, err := os.Stat(scName); err == nil {
+		return cli.NewExitError(errFileExist, 1)
+	}
+
+	basePath := scName
+	fileName := "main.go"
+
+	// create base directory
+	err := os.Mkdir(basePath, os.ModePerm)
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+
+	data := []byte(fmt.Sprintf(smartContractTmpl, scName))
+	err = ioutil.WriteFile(filepath.Join(basePath, fileName), data, 0644)
+	if err != nil {
+		return cli.NewExitError(err, 1)
+	}
+	fmt.Printf("Successfully initialized smart contract [%s]\n", scName)
+	return nil
 }
 
 func contractCompile(ctx *cli.Context) error {

--- a/cli/main_test.go
+++ b/cli/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/urfave/cli"
+)
+
+var (
+	lastExitCode = 0
+	fakeOsExiter = func(rc int) {
+		lastExitCode = rc
+	}
+	fakeErrWriter = &bytes.Buffer{}
+)
+
+func init() {
+	cli.OsExiter = fakeOsExiter
+	cli.ErrWriter = fakeErrWriter
+}
+
+func TestCommand_InitSmartContract(t *testing.T) {
+	app := cli.NewApp()
+	app.Name = "neo-storm"
+	app.Commands = []cli.Command{cli.Command{
+		Name:   "init",
+		Usage:  "initialize a new smart-contract in a directory with boiler plate code",
+		Action: initSmartContract,
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "name, n",
+				Usage: "name of the smart-contract to be initialized",
+			},
+		},
+	},
+	}
+
+	smartContractName := "testcontract"
+	// Setup
+	os.RemoveAll(smartContractName)
+	// Cleanup
+	defer os.RemoveAll(smartContractName)
+
+	err := app.Run([]string{"neo-storm", "init", "--name=testcontract"})
+	if err != nil {
+		t.Errorf("Did not expect to receive error on first-time contract-creation")
+	}
+
+	// Check if the file already exists, after invoking the init command
+	if _, err := os.Stat("testcontract/main.go"); os.IsNotExist(err) {
+		t.Errorf("Smartcontract directory should have been initialized and must contain main.go file.")
+	}
+
+	data, _ := ioutil.ReadFile("testcontract/main.go")
+	if fmt.Sprintf(smartContractTmpl, smartContractName) != string(data) {
+		t.Errorf("Should have generated boilerplate code in main.go file")
+	}
+
+	err = app.Run([]string{"neo-storm", "init", "--name=testcontract"})
+	if err == nil {
+		t.Errorf("Should have thrown error in case the directory already exists")
+	}
+
+}


### PR DESCRIPTION
* A new command `cli init --name testcontract` now creates a directory testcontract/main.go
* The smartcontract go file is named as `main.go`.

Default help:
``` bash
$  ./cli init --help
NAME:
   cli init - initialize a new smart-contract in a directory with boiler plate code

USAGE:
   cli init [command options] [arguments...]

OPTIONS:
   --name value, -n value  name of the smart-contract to be initialized
```

New initialization:
```bash
$  ./cli init -n test
Successfully initialized smart contract [test]
```

In case the directory exists:

```bash
 $  ./cli init --name test
A file with given smart-contract name already exists
```

