### PR TITLE
Implemented Makefile-help parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,30 @@
+.DEFAULT_GOAL := help
 BUILD_DIR=bin
 BIN=neo-storm
 INSTALL_PATH=/usr/local/bin
 
-install: deps
+help:          ## Show available options with this Makefile
+	@grep -F -h "##" $(MAKEFILE_LIST) | grep -v grep | awk 'BEGIN { FS = ":.*?##" }; { printf "%-18s  %s\n", $$1,$$2 }'
+
+install: deps ## Build and install neo-storm cli application
 	@echo "installing neo-storm framework"
 	@go build -o $(BUILD_DIR)/$(BIN) ./cli
 	@cp $(BUILD_DIR)/$(BIN) $(INSTALL_PATH)
 	@echo "done installing, happy coding!"
 
-deps:
+deps:   ## Build all the dependencies.
 	@echo "installing project dependencies"
 	@dep ensure
 
-clean:
+clean:  ## Clean the build-directory
 	@echo "cleaning build artifacts"
+	@go clean -i ./...
 	@rm -rf $(BUILD_DIR)
 
-uninstall:
+uninstall: ## Uninstall the install binary
 	@echo "uninstalling neo-storm framework"
 	@rm -rf $(INSTALL_PATH)/$(BIN)
 
-test:
+test:   ## Execute all the tests and generate cover reports
 	@echo "running tests"
 	@go test ./... -cover


### PR DESCRIPTION
* Default target is now `help`, i.e. in case someone just executes `make`
* Each `make target` has help docs about it.
* `make clean` now also runs `go clean -i ./...`

Running `make` without any target now produces this:
```bash
$  make
help                 Show available options with this Makefile
install              Build and install neo-storm cli application
deps                 Build all the dependencies.
clean                Clean the build-directory
uninstall            Uninstall the install binary
test                 Execute all the tests and generate cover reports```