### PR TITLE
swap arguments for functions with more than 3 arguments

### DIFF
--- a/compiler/codegen.go
+++ b/compiler/codegen.go
@@ -435,6 +435,12 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 				emitInt(c.prog, 2)
 				emitOpcode(c.prog, vm.XSWAP)
 			}
+			if numArgs > 3 {
+				for i := 1; i < numArgs; i++ {
+					emitInt(c.prog, int64(i))
+					emitOpcode(c.prog, vm.ROLL)
+				}
+			}
 		}
 
 		// Check builtin first to avoid nil pointer on funcScope!


### PR DESCRIPTION
### Proposed changes in this pull request
Functions with more than 3 arguments are not working now. 
```
func Main() {
	a := [4]int{0,0,0,0}
	a[0] = 0
	f1(a, 1, 2, 3)
}

func f1(a [4]int, x int, y int, z int) {
	a[1] = x
}
```
I think, I have fixed it with this pull request. What do you think?
`make test` still passes all tests

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/CityOfZion/neo-storm/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [x] Added proper documentation where ever applicable (in code and README.md).

### Extra information
Any extra information related to this pull request.
