### PR TITLE
concatenate strings using CAT opcode

### DIFF
--- a/compiler/codegen.go
+++ b/compiler/codegen.go
@@ -372,14 +372,26 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 			// example:
 			// const x = 10
 			// x + 2 will results into 12
-			if tinfo := c.typeInfo.Types[n]; tinfo.Value != nil {
+			tinfo := c.typeInfo.Types[n]
+			if tinfo.Value != nil {
 				c.emitLoadConst(tinfo)
 				return nil
 			}
 
 			ast.Walk(c, n.X)
 			ast.Walk(c, n.Y)
-			c.convertToken(n.Op)
+
+			// VM has separate opcode for string concatenation
+			if n.Op == token.ADD {
+				typ, ok := tinfo.Type.Underlying().(*types.Basic)
+				if ok && typ.Kind() == types.String {
+					emitOpcode(c.prog, vm.CAT)
+				} else {
+					emitOpcode(c.prog, vm.ADD)
+				}
+			} else {
+				c.convertToken(n.Op)
+			}
 			return nil
 		}
 


### PR DESCRIPTION
### Proposed changes in this pull request
This should fix issue #39 . NEO VM has separate opcode for strings concatenating.

### Type (put an `x` where ever applicable)
- [x] Bug fix: issue #39 
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/CityOfZion/neo-storm/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [x] Added proper documentation where ever applicable (in code and README.md).

### Extra information
Any extra information related to this pull request.
