### PR TITLE
fix argument handling for function arity >= 3

### DIFF
--- a/compiler/codegen.go
+++ b/compiler/codegen.go
@@ -446,27 +446,6 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 				emitInt(c.prog, 2)
 				emitOpcode(c.prog, vm.XSWAP)
 			} else {
-				half := int(numArgs / 2)
-
-				for i := 0; i < half; i++ {
-					to := numArgs - 1 - i
-
-					emitInt(c.prog, int64(to))
-					emitOpcode(c.prog, vm.PICK)
-
-					emitInt(c.prog, int64(i+1))
-					emitOpcode(c.prog, vm.PICK)
-
-					emitInt(c.prog, int64(to+2))
-					emitOpcode(c.prog, vm.XSWAP)
-					emitOpcode(c.prog, vm.DROP)
-
-					emitInt(c.prog, int64(i+1))
-					emitOpcode(c.prog, vm.XSWAP)
-					emitOpcode(c.prog, vm.DROP)
-				}
-			}
-			if numArgs > 3 {
 				for i := 1; i < numArgs; i++ {
 					emitInt(c.prog, int64(i))
 					emitOpcode(c.prog, vm.ROLL)


### PR DESCRIPTION
### Proposed changes in this pull request
There was some work done in #51 regarding handling of functions with more than 3 arguments.
I have tested this right now again (because of issue #57 ) and it didnt't work.
Probably I had forgotten to remove old code. All examples from that PR are working correctly (via testinvoke)

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/CityOfZion/neo-storm/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).

### Extra information
Any extra information related to this pull request.
