### PR TITLE
convert unary operators properly

### DIFF
--- a/compiler/codegen.go
+++ b/compiler/codegen.go
@@ -503,7 +503,22 @@ func (c *codegen) Visit(node ast.Node) ast.Visitor {
 
 	case *ast.UnaryExpr:
 		ast.Walk(c, n.X)
-		c.convertToken(n.Op)
+		// From https://golang.org/ref/spec#Operators
+		// there can be only following unary operators
+		// "+" | "-" | "!" | "^" | "*" | "&" | "<-" .
+		// of which last three are not used in SC
+		switch n.Op {
+		case token.ADD:
+			// +10 == 10, no need to do anything in this case
+		case token.SUB:
+			emitOpcode(c.prog, vm.NEGATE)
+		case token.NOT:
+			emitOpcode(c.prog, vm.NOT)
+		case token.XOR:
+			emitOpcode(c.prog, vm.INVERT)
+		default:
+			log.Fatalf("invalid unary operator: %s", n.Op)
+		}
 		return nil
 
 	case *ast.IncDecStmt:


### PR DESCRIPTION
### Proposed changes in this pull request
Right now unary operators are not converted properly.
This PR adds possibility to use them in smart contracts.

### Type (put an `x` where ever applicable)
- [x] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [x] Read the [CONTRIBUTION guidelines](https://github.com/CityOfZion/neo-storm/blob/master/CONTRIBUTING.md).
- [x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).

### Extra information
Any extra information related to this pull request.
