### PR TITLE
use go mod after go11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 BUILD_DIR=bin
 BIN=neo-storm
 INSTALL_PATH=/usr/local/bin
+GOVERSION := $(shell go version | sed 's/^.*go//g' | sed 's/ .*//g')
+GO110 = 1.10.8
+LOWER=$(shell echo $(GOVERSION) $(GO110) | tr " " "\n" | sort -V | head -n 1)
 
 help:          ## Show available options with this Makefile
 	@grep -F -h "##" $(MAKEFILE_LIST) | grep -v grep | awk 'BEGIN { FS = ":.*?##" }; { printf "%-18s  %s\n", $$1,$$2 }'
@@ -14,7 +17,11 @@ install: deps ## Build and install neo-storm cli application
 
 deps:   ## Build all the dependencies.
 	@echo "installing project dependencies"
+ifeq ($(GOVERSION),$(LOWER))
 	@dep ensure
+else
+	@go mod download
+endif
 
 clean:  ## Clean the build-directory
 	@echo "cleaning build artifacts"

--- a/README.md
+++ b/README.md
@@ -37,15 +37,19 @@ The following section will help you with installing neo-storm and it's dependenc
 ### Golang
 neo-storm requires a working and proper ***Golang*** installation. To install Golang you can check out these [installation instructions](https://golang.org/doc/install).
 
-### Godep
-For package management neo-storm uses ***dep***. To install dep you can check out these [installations instructions](https://github.com/golang/dep).
+### Denpendency
+For package management ,
+* When go version is less than go1.11.0 neo-storm uses ***dep*** . To install dep you can check out these [installations instructions](https://github.com/golang/dep).
+
+* When go version is or greater than go1.11.0, neo-storm uses ***go mod***.
 
 # Installing the neo-storm framework
 ### Unix
-`neo-storm` uses [dep](https://github.com/golang/dep) as its dependency manager. After installing `dep` you can run:
+`neo-storm` uses [dep](https://github.com/golang/dep) as its dependency manager when go version is less than go1.11.0. After installing `dep` you can run:
 ```
 make install
 ```
+> if your go version is greater than go1.11.0, you can run this directly.
 
 After the installation is completed, you can find the binary in `bin/neo-storm` or globally use `neo-storm`.
 


### PR DESCRIPTION
### Proposed changes in this pull request
Makefile only support dep now.
this pr use go mod when go version is greater than 1.10.8

### Type (put an `x` where ever applicable)
- [x ] Bug fix: Link to the issue
- [ ] Feature (Non-breaking change)
- [ ] Feature (Breaking change)
- [ ] Documentation Improvement

### Checklist
Please put an `x` against the checkboxes. Write a small comment explaining if its `N/A` (not applicable)

- [ x] Read the [CONTRIBUTION guidelines](https://github.com/CityOfZion/neo-storm/blob/master/CONTRIBUTING.md).
- [ x] All the tests are passing after the introduction of new changes.
- [ ] Added tests respective to the part of code I have written.
- [ ] Added proper documentation where ever applicable (in code and README.md).

### Extra information
Any extra information related to this pull request.
